### PR TITLE
use buttonLabel translation from YAML, if there is one

### DIFF
--- a/sounding-board/src/views/SoundingBoard.vue
+++ b/sounding-board/src/views/SoundingBoard.vue
@@ -43,7 +43,7 @@
               :key="option"
               :class="option == currentConfiguration[key] ? 'is-danger' : ''"
               @click="setFactor(key, option)"
-            ) {{ option }}
+            ) {{ yaml.buttonLabels && yaml.buttonLabels[option] || option }}
         .left-block
           .conditionTitle {{ textBlocks[key].description}}
           .conditionDescriptionTitle Information:


### PR DESCRIPTION
Will use the button label translation from YAML for each button, if it finds one.

New section in YAML (example):

```yaml
# ------------------------------------
buttonLabels:
    base: Base
    dekarbonisiert: Dekarbonisiert
    start: Stark
    ganze Stadt: Ganze Stadt
    BesucherFossilTeuer_alleAnderenPreswert: Besucher Fossil Teuer
    MautFuerAlle: Maut für Alle
```

@mkreuschner will need to update the YAML to include a `button: text` translation for every button label in the UI, from the R code.

